### PR TITLE
Fix FEN en passant parsing bug

### DIFF
--- a/src/game.c
+++ b/src/game.c
@@ -464,7 +464,7 @@ Game *load_fen_game(const char *filepath) {
 
     if (en_passant_file != '-') {
         en_passant_file -= 'a';
-        en_passant_file -= '1';
+        en_passant_rank -= '1';
 
         uint8_t en_passant_target_square = (en_passant_file * 8) + en_passant_rank;
 


### PR DESCRIPTION
## Summary
- fix incorrect index adjustment for en passant parsing in FEN loader

## Testing
- `make clean && make`
- ran a quick interactive FEN load and perft test

------
https://chatgpt.com/codex/tasks/task_e_684a02a53f7c833090579dbd29d443c8